### PR TITLE
Fix typo in README.md 'optonal'

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Action rows wrap buttons or select menus providing top-level layout.
 
 | Name | Type | Description                        |
 | ---- | ---- | ---------------------------------- |
-| id?  | int  | The optonal identifier for the row |
+| id?  | int  | The optional identifier for the row |
 
 #### Valid children
 - [Button](#button)


### PR DESCRIPTION
As the title says, I reported a typo #14 and had *thought* I saw a fix #15 but it's certainly still there
